### PR TITLE
Modifications to load all files with schema

### DIFF
--- a/ExcelHandler.cs
+++ b/ExcelHandler.cs
@@ -1,38 +1,98 @@
-﻿using System;
+﻿using Sylvan.Data;
+using Sylvan.Data.Excel;
+using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Sylvan.Data.Excel;
 
 namespace ReadExcelUsingSylvan
 {
+
     internal static class ExcelHandler
     {
-        public static DataTable FixHeaders(DataTable dt)
-        {
-            foreach (DataColumn column in dt.Columns)
-            {
-                //these are a few (of many) illegal characters that aren't accepted in the System.Windows.Controls.DataGrid Column Header 
-                column.ColumnName = column.ColumnName.Replace(".", "_").Replace("#", "").Replace("/", " ").Replace(":", " ");
-            }
-
-            return dt;
-        }
-
         public static DataTable SylvanReadExcelFile(string filePath)
         {
             var theData = new DataTable();
 
+            var schema = new CustomSchema()
+                .Add<int>("RowId")
+                .Add<string>("First Name")
+                .Add<string>("Last Name")
+                .Add<string>("Gender")
+                .Add<string>("Country")
+                .Add<int>("Age")
+                .Add<string>("DateString")
+                .Add<int>("Id");
+
             using var edr = ExcelDataReader.Create(filePath, new ExcelDataReaderOptions
             {
                 GetErrorAsNull = true,
+                Schema = schema,
             });
 
-            theData.Load(edr, LoadOption.PreserveChanges);
+            var idx = edr.GetOrdinal("DateString");
+
+            // transform the raw ExcelDataReader to fix/workaround a couple issues
+            var dr =
+                edr
+                // there is a blank row in the file. Skip it
+                .Where(r => !r.IsDBNull(0))
+                // attach a new column that
+                .WithColumns(new CustomDataColumn<DateTime>("Date", r => DateTime.ParseExact(r.GetString(idx), "dd/MM/yyyy", null)));
+
+            // finally, select everything excep the DateString column
+            dr = dr.Select(d => d.GetColumnSchema().Where(c => c.ColumnName != "DateString").Select(c => c.ColumnOrdinal!.Value).ToArray());
+
+
+            theData.Load(dr, LoadOption.PreserveChanges);
 
             return theData;
         }
+
+        sealed class CustomSchema : IExcelSchemaProvider
+        {
+            List<Column> columns;
+
+            public CustomSchema()
+            {
+                this.columns = new List<Column>();
+            }
+
+            public CustomSchema Add<T>(string name)
+            {
+                this.columns.Add(new Column(name, columns.Count, typeof(T)));
+                return this;
+            }
+
+            class Column : DbColumn
+            {
+                public Column(string name, int ordinal, Type type)
+                {
+                    this.ColumnName = name;
+                    this.ColumnOrdinal = ordinal;
+                    this.DataType = type;
+                }
+            }
+
+            public int GetFieldCount(ExcelDataReader reader)
+            {
+                // this handles the empty header row, which would otherwise be detected as 0 columns.
+                return this.columns.Count;
+            }
+
+            public DbColumn? GetColumn(string sheetName, string? name, int ordinal)
+            {
+                // match by oridnal only, ignore any header in the file, which would include the "bad" headers.
+                return ordinal < columns.Count ? columns[ordinal] : null;
+            }
+
+            public bool HasHeaders(string sheetName)
+            {
+                // the first row in your file is always a header (non-data) row.
+                return true;
+            }
+        }
+
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -42,7 +42,7 @@ namespace ReadExcelUsingSylvan
             //The only issue I found in Sylvan.Data.Excel is when you import data where the first row is empty. Which isn't an issue for me.
 
             //to see header issue, DataTable dt = SylvanReadExcelFile(fileDialog.FileName);
-            DataTable dt = FixHeaders(SylvanReadExcelFile(fileDialog.FileName));
+            DataTable dt = SylvanReadExcelFile(fileDialog.FileName);
 
             watch.Stop();
             System.Diagnostics.Debug.WriteLine(watch.ElapsedMilliseconds + "\tms");

--- a/ReadExcelUsingSylvan.csproj
+++ b/ReadExcelUsingSylvan.csproj
@@ -8,7 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Sylvan.Data" Version="0.2.3" />
     <PackageReference Include="Sylvan.Data.Excel" Version="0.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<ProjectReference Include="..\..\Sylvan.Data.Excel\source\Sylvan.Data.Excel\Sylvan.Data.Excel.csproj" />
+    <ProjectReference Include="..\..\Sylvan\source\Sylvan.Data\Sylvan.Data.csproj" />-->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Thanks for sharing your examples with me. It's always interesting to see how people use my libraries and the issues they run into.

Here are some changes that allow all 3 files to be loaded properly. I tried to add some comments to explain why something are done. Feel free to ask for clarification if something doesn't make sense. 

I've added a custom schema implementation that allows you to specify the data types for the columns. The custom schema allows you to specify a specific name and type for each of the columns. This allows the data table to load the strongly typed data instead of strings.

The dates in your sheets are all stored as strings instead of being a proper Excel date, this is unusual. My library doesn't do a great job of handling this right now, it simply tries to parse the date with Date.Parse, and doesn't specify a culture. This means the CurrentCulture should be used. This date format "dd/MM/yyyy", is that the default on your system? What country/culture do you use? I'd like to improve my library to make this a bit easier, but I've shown how you can work around this with some transformations using the Sylvan.Data library.

There is a blank row in each of these files (83), which causes some issues. I've shown how you can filter that out as well with the "Where" extension.